### PR TITLE
30 discripancy in gpu count in partition vs all partitions

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,14 +98,15 @@ router.get('/api/jobs', async (req, res) => {
   res.json(result);
 });
 
-router.get('/api/stats/', (req, res) => {
+router.get('/api/stats/', async (req, res) => {
   try {
-    const partition = req.query.partition || 'all';
+    const partition = req.query.partition;
     
-    // Get stats specific to partition if it's not 'all'
-    const cpuStats = getCPUsByState(partition !== 'all' ? partition : null);
-    const memStats = getMemByState(partition !== 'all' ? partition : null);
-    const gpuStats = getGPUByState(partition !== 'all' ? partition : null);
+    // treat 'all' as null
+    const partitionParam = partition === 'all' || !partition ? null : partition;
+    const cpuStats = getCPUsByState(partitionParam);
+    const memStats = getMemByState(partitionParam);
+    const gpuStats = await getGPUByState(partitionParam);
     
     res.json({
       success: true,
@@ -135,7 +136,7 @@ router.get('/', async (req, res) => {
   // Get stats
   const cpuStats = getCPUsByState();
   const memStats = getMemByState();
-  const gpuStats = getGPUByState();
+  const gpuStats = await getGPUByState();
   //TODO: fetch partitions dynamically
   const partitions = getPartitions()
   

--- a/handlers/fetchStats.js
+++ b/handlers/fetchStats.js
@@ -1,4 +1,4 @@
-const { executeCommand } = require("../helpers/executeCmd.js");
+const { executeCommand, executeCommandStreaming } = require("../helpers/executeCmd.js");
 
 // Fetches the number of CPUs by state
 function getCPUsByState(partition = null) {
@@ -27,7 +27,7 @@ function getMemByState(partition = null) {
         }
 
         lines.forEach((line) => {
-            if(!line.trim()) return;
+            if (!line.trim()) return;
 
             //check if node belongs to current partition
             if (partition) {
@@ -42,23 +42,23 @@ function getMemByState(partition = null) {
             const allocMemMatch = line.match(/AllocMem=(\d+)/);
             const freeMemMatch = line.match(/FreeMem=(\d+)/);
             const stateMatch = line.match(/State=(\S+)/);
-            
+
             if (realMemMatch && stateMatch) {
                 const nodeState = stateMatch[1].toUpperCase();
                 const realMem = parseInt(realMemMatch[1], 10);
                 const allocMem = allocMemMatch ? parseInt(allocMemMatch[1], 10) : 0;
                 const freeMem = freeMemMatch ? parseInt(freeMemMatch[1], 10) : 0;
-                
+
                 // Add to total memory
                 distribution.total += realMem;
-                
+
                 // Categorize memory based on node state
                 if (nodeState.includes("DOWN") || nodeState.includes("DRAIN")) {
                     distribution.down += realMem;
                 } else {
                     distribution.allocated += allocMem;
                     distribution.idle += freeMem;
-                    
+
                     // Calculate other memory (difference between total, allocated and free)
                     const otherMem = Math.max(0, realMem - allocMem - freeMem);
                     distribution.other += otherMem;
@@ -83,99 +83,95 @@ function getMemByState(partition = null) {
     }
 }
 
-function getGPUByState(partition = null) {
+async function getGPUByState(partition = null) {
     try {
         const partitionFlag = partition ? `-p ${partition}` : '';
-        const availableGPUsOutput = executeCommand(`sinfo ${partitionFlag} -h -O Gres | grep -v '(null)' | grep gpu`);
+
+        // Get Total GPUs from scontrol
+        const scontrolOutput = await executeCommandStreaming('scontrol show node -o');
+        const nodeLines = scontrolOutput.trim().split("\n");
+
+        const gpuTotals = {};
+        const gresRegex = /gpu:([^:]+):(\d+)/g;
+
+        nodeLines.forEach(line => {
+            if (!line.trim()) return;
+
+            // If a partition is specified, filter nodes by checking their Partitions list.
+            if (partition) {
+                const partitionMatch = line.match(/Partitions=([^\s]+)/);
+                // Skip this node if it doesn't belong to the requested partition.
+                if (!partitionMatch || !partitionMatch[1].split(',').includes(partition)) {
+                    return;
+                }
+            }
+
+            const gresMatch = line.match(/Gres=([^\s]+)/);
+            if (gresMatch) {
+                const gresString = gresMatch[1];
+                let match;
+                // Loop through all gpu entries in the gres string (e.g., "gpu:a100:8,gpu:v100:4")
+                while ((match = gresRegex.exec(gresString)) !== null) {
+                    const gpuType = match[1];
+                    const count = Number(match[2]);
+                    gpuTotals[gpuType] = (gpuTotals[gpuType] || 0) + count;
+                }
+            }
+        });
+
+        // Get Used GPUs from sinfo
         const usedGPUsOutput = executeCommand(`sinfo ${partitionFlag} -h -O GresUsed | grep -v '(null)' | grep gpu`);
+        const usedLines = usedGPUsOutput.trim() ? usedGPUsOutput.trim().split("\n") : []; // Handle empty output safely
 
-        // Parse available GPUs
-        const gpuTypes = {};
-        let totalGPUs = 0;
-        let totalUsed = 0;
-        
-        const availableLines = availableGPUsOutput.trim().split("\n");
+        const gpuUsed = {};
+        const usedRegex = /gpu:([^:(]+):(\d+)/g;
 
-        availableLines.forEach(line => {
-            // Extract GPU type and count
-            const match = line.match(/gpu:([^:(]+)(?:[^:]*):(\d+)/);
-            if (match) {
-                const gpuType = match[1].trim();
-                const count = parseInt(match[2], 10);
-                
-                if (!gpuTypes[gpuType]) {
-                    gpuTypes[gpuType] = { total: 0, used: 0 };
-                }
-                
-                gpuTypes[gpuType].total += count;
-                totalGPUs += count;
-            }
-        });
-
-        // Parse used GPUs
-        const usedLines = usedGPUsOutput.trim().split("\n");
-        
         usedLines.forEach(line => {
-            const match = line.match(/gpu:([^:(]+)(?:[^:]*):(\d+)/);
-            if (match) {
-                const gpuType = match[1].trim();
-                const usedCount = parseInt(match[2], 10);
-                
-                if (gpuTypes[gpuType]) {
-                    gpuTypes[gpuType].used += usedCount;
-                    totalUsed += usedCount;
-                }
+            let match;
+            while ((match = usedRegex.exec(line)) !== null) {
+                const gpuType = match[1];
+                const count = Number(match[2]);
+                gpuUsed[gpuType] = (gpuUsed[gpuType] || 0) + count;
             }
         });
 
-        // Create hierarchical structure with Used/Available as first level
-        // and GPU types as second level
+        // combine totals and used
+        const gpuTypes = {};
+        Object.keys(gpuTotals).forEach(gpuType => {
+            gpuTypes[gpuType] = {
+                total: gpuTotals[gpuType],
+                used: gpuUsed[gpuType] || 0, // Default to 0 if no GPUs of this type are currently in use.
+            };
+        });
+
+        // genreate response
         const gpuStats = {
             name: "GPU Utilization",
-            children: [
-                {
-                    name: "Used",
-                    children: []
-                },
-                {
-                    name: "Available",
-                    children: []
-                }
-            ]
+            children: [{ name: "Used", children: [] }, { name: "Available", children: [] }],
         };
-        
-        // Add GPU types as second level
+
         Object.keys(gpuTypes).forEach(gpuType => {
             const typeData = gpuTypes[gpuType];
             const used = typeData.used;
-            const available = typeData.total - typeData.used;
-            
-            // Add to Used category if there are used GPUs of this type
+            // Ensure 'available' is not negative due to any transient mis-sync in Slurm states.
+            const available = Math.max(0, typeData.total - used);
+
             if (used > 0) {
-                gpuStats.children[0].children.push({
-                    name: gpuType,
-                    value: used
-                });
+                gpuStats.children[0].children.push({ name: gpuType, value: used });
             }
-            
-            // Add to Available category if there are available GPUs of this type
             if (available > 0) {
-                gpuStats.children[1].children.push({
-                    name: gpuType,
-                    value: available
-                });
+                gpuStats.children[1].children.push({ name: gpuType, value: available });
             }
         });
-        
+
         return gpuStats;
 
     } catch (error) {
         console.error('Error in getGPUByState:', error.message);
+        // Return a consistent error structure for the frontend to handle.
         return {
             name: "GPU Utilization",
-            children: [
-                { name: "Error", value: 1 }
-            ]
+            children: [{ name: "Error", value: 1, message: error.message }],
         };
     }
 }


### PR DESCRIPTION
fix: use `scontrol show node` to calculate available gpus instead of `sinfo`. note: `sinfo` is still used to find allocated gres