### PR TITLE
update error handling for zero GPUs

### DIFF
--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -87,6 +87,14 @@
     if (containerId === "sunburst-chart-gpu") {
       // For GPU chart - use semantic colors based on usage state
       color = d => {
+        // Special case for zero GPUs - use allocated color to indicate "no available GPUs"
+        if (d.data.name === "No GPUs") {
+          return "#e63946"; // Red color for "no available GPUs"
+        }
+        // Special case for errors - use a distinct error color
+        if (d.data.name === "Error") {
+          return "#8b5cf6"; // Purple color for errors
+        }
         // First level: Used vs Available
         if (d.depth === 1) {
           return d.data.name === "Used" ? "#e63946" : "#2a9d8f"; // Red for used, Green for available
@@ -133,7 +141,12 @@
       .attr("viewBox", [-radius, -radius, width, width]).style("height", "400px")
       .style("font", "10px sans-serif");
 
-    const total = root.value;
+    // For GPU charts, use totalGPUs if available, otherwise use the sum of values
+    let total = root.value;
+    if (containerId === "sunburst-chart-gpu" && data.totalGPUs !== undefined) {
+      total = data.totalGPUs;
+    }
+    
     // Add central label.
     svg.append("text")
       .attr("text-anchor", "middle")


### PR DESCRIPTION
Fixes #37 

- The root cause for this was the exit code of this command when it's run against a partition with no GPUs, `sinfo -p partition -h -O GresUsed | grep -v '(null)' | grep gpu`. The second step would remove all (null) lines and would cause the exit code 1. We now handle this gracefully and return an appropriate response for zero-GPU cases.
- Also added tests for this case
- `totalGPUs` is now returned by the `fetchStats` handler

The UI now looks like
<img width="545" height="632" alt="Image" src="https://github.com/user-attachments/assets/bd1294f6-b426-4c22-a5b9-5ce14c8f2b57" />
